### PR TITLE
Added the ability to react to roles (user and admin)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hookform/resolvers": "^3.3.3",
         "@prisma/client": "^5.7.1",
         "@radix-ui/react-alert-dialog": "^1.0.5",
+        "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -2605,6 +2606,32 @@
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.0.4.tgz",
+      "integrity": "sha512-kVK2K7ZD3wwj3qhle0ElXhOjbezIgyl2hVvgwfIdexL3rN6zJmy5AqqIf+D31lxVppdzV8CjAfZ6PklkmInZLw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@hookform/resolvers": "^3.3.3",
     "@prisma/client": "^5.7.1",
     "@radix-ui/react-alert-dialog": "^1.0.5",
+    "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.0.4",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,0 +1,35 @@
+import {api} from "@/trpc/server";
+import {UserProfileForm} from "@/components/organisms/profile/user-profile-form";
+import {UserProfile} from "@/components/organisms/profile/user-profile";
+import {Card, CardContent, CardHeader} from "@/components/ui/card";
+import Link from "next/link";
+import {Button} from "@/components/ui/button";
+
+export default async function MyUserRedirectPage() {
+
+  const user = await api.user.me.query();
+
+  return (
+    <div className={"md:flex w-[100%] md:space-x-10"}>
+      <div className={"flex-1"}>
+        <UserProfileForm
+          user={user}
+        />
+      </div>
+      <Card className={"flex-2 mt-8 md:mt-0"}>
+        <CardHeader>
+          <div className={"flex justify-between"}>
+            <h1 className={"text-2xl font-bold"}>Your Profile</h1>
+            <Link className={""} href={`/users/${user.userId}`}>
+              <Button>Visit</Button>
+            </Link>
+          </div>
+        </CardHeader>
+        <CardContent className={"px-3"}>
+          <UserProfile user={user}/>
+        </CardContent>
+      </Card>
+
+    </div>
+  );
+}

--- a/src/app/users/[user]/page.tsx
+++ b/src/app/users/[user]/page.tsx
@@ -1,0 +1,22 @@
+import {api} from "@/trpc/server";
+import {UserProfile} from "@/components/organisms/profile/user-profile";
+import {type WithUrlParams} from "@/lib/next-app.types";
+
+export type UserProfileProps = {
+  user: string;
+}
+
+export default async function User({params}: WithUrlParams<UserProfileProps>) {
+
+  const user = await api.user.get.query({
+    userId: params.user
+  });
+
+  return (
+    <div>
+      <UserProfile
+        user={user}
+      />
+    </div>
+  );
+}

--- a/src/components/organisms/profile/user-profile-form.tsx
+++ b/src/components/organisms/profile/user-profile-form.tsx
@@ -11,6 +11,7 @@ import {UpdateUserProfileDto} from "@/dtos/profile/update-profile.dto";
 import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
 import {Textarea} from "@/components/ui/textarea";
 import {api} from "@/trpc/react";
+import {useRouter} from "next/navigation";
 
 export type UserProfileProps = {
   user: UserProfileDto;
@@ -19,11 +20,13 @@ export type UserProfileProps = {
 export const UserProfileForm: FC<UserProfileProps> = ({user}) => {
 
   const updateUser = api.user.update.useMutation();
+  const router = useRouter();
 
   const form = useForm<z.infer<typeof UpdateUserProfileDto>>({
     resolver: zodResolver(UpdateUserProfileDto),
     defaultValues: {
-      displayName: user.displayName,
+      firstName: user.firstName,
+      lastName: user.lastName,
       title: user.title,
       company: user.company,
       description: user.description,
@@ -34,6 +37,7 @@ export const UserProfileForm: FC<UserProfileProps> = ({user}) => {
 
   const onSubmit = useCallback((values: z.infer<typeof UpdateUserProfileDto>) => {
     updateUser.mutate(values);
+    router.refresh();
   }, []);
 
   return (
@@ -41,16 +45,26 @@ export const UserProfileForm: FC<UserProfileProps> = ({user}) => {
       <form onSubmit={form.handleSubmit(onSubmit)} className={"space-y-3"}>
         <FormField
           control={form.control}
-          name={"displayName"}
+          name={"firstName"}
           render={({field}) => (
             <FormItem>
-              <FormLabel>Display Name</FormLabel>
+              <FormLabel>First Name</FormLabel>
               <FormControl>
-                <Input placeholder={"display name"} {...field} />
+                <Input placeholder={"first name"} {...field} />
               </FormControl>
-              <FormDescription>
-                This is the name that people see when they look at your profile
-              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={"lastName"}
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Last Name</FormLabel>
+              <FormControl>
+                <Input placeholder={"last name"} {...field} />
+              </FormControl>
               <FormMessage/>
             </FormItem>
           )}

--- a/src/components/organisms/profile/user-profile-form.tsx
+++ b/src/components/organisms/profile/user-profile-form.tsx
@@ -35,8 +35,8 @@ export const UserProfileForm: FC<UserProfileProps> = ({user}) => {
     }
   });
 
-  const onSubmit = useCallback((values: z.infer<typeof UpdateUserProfileDto>) => {
-    updateUser.mutate(values);
+  const onSubmit = useCallback(async (values: z.infer<typeof UpdateUserProfileDto>) => {
+    await updateUser.mutateAsync(values);
     router.refresh();
   }, []);
 

--- a/src/components/organisms/profile/user-profile-form.tsx
+++ b/src/components/organisms/profile/user-profile-form.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import {type FC, useCallback} from "react";
+import {Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage} from "@/components/ui/form";
+import {useForm} from "react-hook-form";
+import {Input} from "@/components/ui/input";
+import {type z} from "zod";
+import {zodResolver} from "@hookform/resolvers/zod";
+import {Button} from "@/components/ui/button";
+import {UpdateUserProfileDto} from "@/dtos/profile/update-profile.dto";
+import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
+import {Textarea} from "@/components/ui/textarea";
+import {api} from "@/trpc/react";
+
+export type UserProfileProps = {
+  user: UserProfileDto;
+}
+
+export const UserProfileForm: FC<UserProfileProps> = ({user}) => {
+
+  const updateUser = api.user.update.useMutation();
+
+  const form = useForm<z.infer<typeof UpdateUserProfileDto>>({
+    resolver: zodResolver(UpdateUserProfileDto),
+    defaultValues: {
+      displayName: user.displayName,
+      title: user.title,
+      company: user.company,
+      description: user.description,
+      socials: user.socials,
+      avatarUrl: user.avatarUrl
+    }
+  });
+
+  const onSubmit = useCallback((values: z.infer<typeof UpdateUserProfileDto>) => {
+    updateUser.mutate(values);
+  }, []);
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className={"space-y-3"}>
+        <FormField
+          control={form.control}
+          name={"displayName"}
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Display Name</FormLabel>
+              <FormControl>
+                <Input placeholder={"display name"} {...field} />
+              </FormControl>
+              <FormDescription>
+                This is the name that people see when they look at your profile
+              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={"title"}
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Title</FormLabel>
+              <FormControl>
+                <Input placeholder={"your job title"} {...field} />
+              </FormControl>
+              <FormDescription>
+                What do you work as?
+              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={"description"}
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Description</FormLabel>
+              <FormControl>
+                <Textarea placeholder={"description"} {...field} />
+              </FormControl>
+              <FormDescription>
+                A brief description of yourself
+              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={"company"}
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Company</FormLabel>
+              <FormControl>
+                <Input placeholder={"company name"} {...field} disabled={true}/>
+              </FormControl>
+              <FormDescription>
+                Currently not available.
+              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name={"socials"}
+          render={({field}) => (
+            <FormItem>
+              <FormLabel>Socials</FormLabel>
+              <FormControl>
+                <Input placeholder={"social media link"} {...field} />
+              </FormControl>
+              <FormDescription>
+                Your preferred social media presence
+              </FormDescription>
+              <FormMessage/>
+            </FormItem>
+          )}
+        />
+        <div className={"flex justify-end"}>
+          <Button type={"submit"}>Update Profile</Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+

--- a/src/components/organisms/profile/user-profile.tsx
+++ b/src/components/organisms/profile/user-profile.tsx
@@ -4,6 +4,7 @@ import React, {type FC, useMemo} from "react";
 import Link from "next/link";
 import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
 import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar";
+import {convertUrlToSlugWithDomain} from "@/lib/format/convert-url-to-slug-with-domain";
 
 export type UserProfileProps = {
   user: UserProfileDto;
@@ -12,10 +13,10 @@ export type UserProfileProps = {
 
 export const UserProfile: FC<UserProfileProps> = ({user}) => {
 
-  const prettySocials = useMemo(() => {
-    // trim away the http(s)://www
-    return user.socials?.replace(/(^\w+:|^)\/\//, "").replace("www.", "");
-  }, []);
+  const prettySocials = useMemo(
+    () => convertUrlToSlugWithDomain(user.socials ?? ""),
+    [user.socials]
+  );
 
   return (
     <div className={"md:flex md:space-x-4"}>

--- a/src/components/organisms/profile/user-profile.tsx
+++ b/src/components/organisms/profile/user-profile.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import React, {type FC, useMemo} from "react";
+import Link from "next/link";
+import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
+import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar";
+
+export type UserProfileProps = {
+  user: UserProfileDto;
+}
+
+
+export const UserProfile: FC<UserProfileProps> = ({user}) => {
+
+  const prettySocials = useMemo(() => {
+    // trim away the http(s)://www
+    return user.socials?.replace(/(^\w+:|^)\/\//, "").replace("www.", "");
+  }, []);
+
+  return (
+    <div className={"md:flex md:space-x-4"}>
+      <Avatar className={"rounded w-[100%] h-auto md:h-56 md:w-56"}>
+        <AvatarImage src={user.avatarUrl} alt={"profile picture"}/>
+        <AvatarFallback>DP</AvatarFallback>
+      </Avatar>
+      <div>
+        <div className={"text-center mt-2 md:text-left"}>
+          <h1 className={"text-4xl font-bold"}>{user.displayName}</h1>
+          {user.title ? <p>{user.title}</p> : <p className={"text-muted italic"}>no title</p>}
+        </div>
+        <div className={"mb-2 text-center md:text-left"}>
+          <Link
+            className={"text-primary hover:underline"}
+            href={user.socials ?? ""}
+            target={"_blank"}>
+            {prettySocials}
+          </Link>
+        </div>
+        <div>
+          <h2 className={"text-2xl font-bold"}>Company</h2>
+          {
+            user.company
+              ? <p>{user.company}</p>
+              : <p className={"italic"}>Individual</p>
+          }
+        </div>
+        <div className={"mt-5"}>
+          <h2 className={"text-2xl font-bold"}>About</h2>
+          <section>
+            {
+              user.description
+                ? <p>{user.description}</p>
+                : <p className={"text-muted italic"}>No description</p>
+            }
+          </section>
+        </div>
+      </div>
+
+    </div>
+  )
+}

--- a/src/components/organisms/profile/user-profile.tsx
+++ b/src/components/organisms/profile/user-profile.tsx
@@ -22,7 +22,7 @@ export const UserProfile: FC<UserProfileProps> = ({user}) => {
     <div className={"md:flex md:space-x-4"}>
       <Avatar className={"rounded w-[100%] h-auto md:h-56 md:w-56"}>
         <AvatarImage src={user.avatarUrl} alt={"profile picture"}/>
-        <AvatarFallback>DP</AvatarFallback>
+        <AvatarFallback className={"rounded"}>{user.initials}</AvatarFallback>
       </Avatar>
       <div>
         <div className={"text-center mt-2 md:text-left"}>

--- a/src/components/restricted-to-role.tsx
+++ b/src/components/restricted-to-role.tsx
@@ -1,0 +1,31 @@
+import {type UserRoleDto} from "@/dtos/user/user-role.dto";
+import {type FC, type PropsWithChildren} from "react";
+import {api} from "@/trpc/react";
+
+export type RestrictedToRoleProps = {
+  role: UserRoleDto;
+}
+
+/**
+ * React component that restricts the rendering of its children based on the user's role.
+ * @component
+ * @example
+ * // Usage:
+ * <RestrictedToRole role={"admin"}>
+ *   <p>I am an admin</p>
+ * </RestrictedToRole>
+ */
+export const RestrictedToRole: FC<PropsWithChildren<RestrictedToRoleProps>> = (props) => {
+
+  const userRole = api.authorization.role.useQuery();
+
+  if (!userRole.data) {
+    return null;
+  }
+
+  if (userRole.data !== props.role) {
+    return null;
+  }
+
+  return props.children;
+}

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -1,15 +1,15 @@
 import Link from "next/link";
 import Image from "next/image";
 import flowcoreLogo from "@/images/flowcore-logo.svg";
-import { Nav } from "./nav";
-import { Home, Users } from "lucide-react";
+import {Nav} from "./nav";
+import {Home, User, Users} from "lucide-react";
 
 interface SidebarProps {
   isSidebarOpen?: boolean;
   setIsSidebarOpen?: (isOpen: boolean) => void;
 }
 
-const Sidebar = ({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) => {
+const Sidebar = ({isSidebarOpen, setIsSidebarOpen}: SidebarProps) => {
   return (
     <aside className="w-42 flex h-screen flex-col bg-slate-700 p-4 text-white ">
       <div className="mb-8 flex flex-col items-start">
@@ -21,7 +21,7 @@ const Sidebar = ({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) => {
             }
           }}
         >
-          <Image src={flowcoreLogo as string} alt="Flowcore" priority />
+          <Image src={flowcoreLogo as string} alt="Flowcore" priority/>
         </Link>
       </div>
       <Nav
@@ -40,6 +40,13 @@ const Sidebar = ({ isSidebarOpen, setIsSidebarOpen }: SidebarProps) => {
             superuserRequired: true,
             icon: Users,
           },
+          {
+            href: "/me",
+            title: "Profile",
+            label: "",
+            superuserRequired: false,
+            icon: User,
+          }
         ]}
         isSidebarOpen={isSidebarOpen}
         setIsSidebarOpen={setIsSidebarOpen}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+
+import { cn } from "@/lib/utils"
+
+const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+      className
+    )}
+    {...props}
+  />
+))
+Avatar.displayName = AvatarPrimitive.Root.displayName
+
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,12 +1,14 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import {cn} from "@/lib/utils"
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({className, ...props}, ref) => {
     return (
       <textarea
         className={cn(
@@ -21,4 +23,4 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
 )
 Textarea.displayName = "Textarea"
 
-export { Textarea }
+export {Textarea}

--- a/src/dtos/profile/update-profile.dto.ts
+++ b/src/dtos/profile/update-profile.dto.ts
@@ -1,0 +1,10 @@
+import {z} from "zod";
+
+export const UpdateUserProfileDto = z.object({
+  displayName: z.string().min(1).max(255),
+  title: z.string().optional(),
+  description: z.string().optional().default(""),
+  socials: z.string().optional(),
+  company: z.string().optional(),
+  avatarUrl: z.string().optional(),
+})

--- a/src/dtos/profile/update-profile.dto.ts
+++ b/src/dtos/profile/update-profile.dto.ts
@@ -1,7 +1,8 @@
 import {z} from "zod";
 
 export const UpdateUserProfileDto = z.object({
-  displayName: z.string().min(1).max(255),
+  firstName: z.string().min(1).max(255),
+  lastName: z.string().min(1).max(255),
   title: z.string().optional(),
   description: z.string().optional().default(""),
   socials: z.string().optional(),

--- a/src/dtos/profile/user-profile.dto.ts
+++ b/src/dtos/profile/user-profile.dto.ts
@@ -1,0 +1,9 @@
+export type UserProfileDto = {
+  userId: string;
+  displayName: string;
+  title?: string;
+  description?: string;
+  socials?: string;
+  company?: string;
+  avatarUrl?: string;
+}

--- a/src/dtos/profile/user-profile.dto.ts
+++ b/src/dtos/profile/user-profile.dto.ts
@@ -6,4 +6,5 @@ export type UserProfileDto = {
   socials?: string;
   company?: string;
   avatarUrl?: string;
+  initials: string;
 }

--- a/src/dtos/profile/user-profile.dto.ts
+++ b/src/dtos/profile/user-profile.dto.ts
@@ -1,6 +1,8 @@
 export type UserProfileDto = {
   userId: string;
   displayName: string;
+  firstName: string;
+  lastName: string;
   title?: string;
   description?: string;
   socials?: string;

--- a/src/dtos/user/user-by-id.dto.ts
+++ b/src/dtos/user/user-by-id.dto.ts
@@ -1,0 +1,5 @@
+import {z} from "zod";
+
+export const UserByIdDto = z.object({
+  userId: z.string().min(1)
+})

--- a/src/dtos/user/user-role.dto.ts
+++ b/src/dtos/user/user-role.dto.ts
@@ -1,0 +1,1 @@
+export type UserRoleDto = "admin" | "user";

--- a/src/lib/format/convert-url-to-slug-with-domain.ts
+++ b/src/lib/format/convert-url-to-slug-with-domain.ts
@@ -1,0 +1,9 @@
+const REGEX_FIND_HTTP_PROTOCOL_AND_WWW = /^(?:https?:\/\/)?(?:www\.)?/;
+
+export const convertUrlToSlugWithDomain = (url: string) => {
+  if (url) {
+    return "";
+  }
+
+  return url.replace(REGEX_FIND_HTTP_PROTOCOL_AND_WWW, "")
+}

--- a/src/lib/next-app.types.ts
+++ b/src/lib/next-app.types.ts
@@ -1,0 +1,6 @@
+/**
+ * A TypeScript utility type used in Next.js pages.
+ * @typeparam T - T represents the shape of the parameters that would be received from a URL in a Next.js page.
+ * @property params - An object that consists of URL parameters in Next.js.
+ */
+export type WithUrlParams<T extends object> = { params: T }

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,6 +1,7 @@
 import {createTRPCRouter} from "@/server/api/trpc";
 import {contactRouter} from "./routers/contact";
 import {userRouter} from "@/server/api/routers/user";
+import {authorizationRouter} from "@/server/api/routers/authorization";
 
 /**
  * This is the primary router for your server.
@@ -9,7 +10,8 @@ import {userRouter} from "@/server/api/routers/user";
  */
 export const appRouter = createTRPCRouter({
   contact: contactRouter,
-  user: userRouter
+  user: userRouter,
+  authorization: authorizationRouter,
 });
 
 // export type definition of API

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
-import { createTRPCRouter } from "@/server/api/trpc";
-import { contactRouter } from "./routers/contact";
+import {createTRPCRouter} from "@/server/api/trpc";
+import {contactRouter} from "./routers/contact";
+import {userRouter} from "@/server/api/routers/user";
 
 /**
  * This is the primary router for your server.
@@ -8,6 +9,7 @@ import { contactRouter } from "./routers/contact";
  */
 export const appRouter = createTRPCRouter({
   contact: contactRouter,
+  user: userRouter
 });
 
 // export type definition of API

--- a/src/server/api/routers/authorization.ts
+++ b/src/server/api/routers/authorization.ts
@@ -1,0 +1,18 @@
+import {createTRPCRouter, protectedProcedure} from "@/server/api/trpc";
+import {type UserRoleDto} from "@/dtos/user/user-role.dto";
+import {clerkClient} from "@clerk/nextjs/server";
+
+export const authorizationRouter = createTRPCRouter({
+  role: protectedProcedure
+    .query(async ({ctx}): Promise<UserRoleDto> => {
+      const userId = ctx.auth?.userId;
+      if (!userId) {
+        throw new Error("User not found");
+      }
+
+      const user = await clerkClient.users.getUser(userId);
+      const privateMetadata = user.privateMetadata;
+      
+      return privateMetadata.role as UserRoleDto ?? "user";
+    }),
+});

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -1,0 +1,56 @@
+import {createTRPCRouter, protectedProcedure} from "@/server/api/trpc";
+import {clerkClient} from "@clerk/nextjs/server";
+import {UserByIdDto} from "@/dtos/user/user-by-id.dto";
+import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
+import {UpdateUserProfileDto} from "@/dtos/profile/update-profile.dto";
+
+export const userRouter = createTRPCRouter({
+  get: protectedProcedure
+    .input(UserByIdDto)
+    .query(async ({input}): Promise<UserProfileDto> => {
+
+      const user = await clerkClient.users.getUser(input.userId);
+      const displayName = `${user.firstName} ${user.lastName}`;
+
+      return {
+        userId: user.id,
+        displayName: displayName,
+        description: "",
+        title: "",
+        socials: "",
+        company: "",
+        avatarUrl: user.imageUrl
+      }
+    }),
+
+  me: protectedProcedure
+    .query(async ({ctx}): Promise<UserProfileDto> => {
+
+      const userId = ctx.auth?.userId;
+      if (!userId) {
+        throw new Error("User not found");
+      }
+
+      // todo: refactor duplicated code
+      const user = await clerkClient.users.getUser(userId);
+      const displayName = `${user.firstName} ${user.lastName}`;
+
+      return {
+        userId: user.id,
+        displayName: displayName,
+        description: "",
+        title: "",
+        socials: "",
+        company: "",
+        avatarUrl: user.imageUrl
+      }
+    }),
+
+  update: protectedProcedure
+    .input(UpdateUserProfileDto)
+    .mutation(async ({input}): Promise<boolean> => {
+      // todo: push changes to flowcore
+      console.log("user updated", input);
+      return true;
+    })
+})

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -3,6 +3,7 @@ import {clerkClient} from "@clerk/nextjs/server";
 import {UserByIdDto} from "@/dtos/user/user-by-id.dto";
 import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
 import {UpdateUserProfileDto} from "@/dtos/profile/update-profile.dto";
+import {getInitialsFromString} from "@/server/lib/format/get-initials-from-string";
 
 export const userRouter = createTRPCRouter({
   get: protectedProcedure
@@ -19,7 +20,8 @@ export const userRouter = createTRPCRouter({
         title: "",
         socials: "",
         company: "",
-        avatarUrl: user.imageUrl
+        avatarUrl: user.imageUrl,
+        initials: getInitialsFromString(displayName),
       }
     }),
 
@@ -42,7 +44,8 @@ export const userRouter = createTRPCRouter({
         title: "",
         socials: "",
         company: "",
-        avatarUrl: user.imageUrl
+        avatarUrl: user.imageUrl,
+        initials: getInitialsFromString(displayName),
       }
     }),
 

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -13,13 +13,21 @@ export const userRouter = createTRPCRouter({
       const user = await clerkClient.users.getUser(input.userId);
       const displayName = `${user.firstName} ${user.lastName}`;
 
+      const metadata = user.publicMetadata;
+      const description: string = metadata.description as string ?? "";
+      const title: string = metadata.title as string ?? "";
+      const socials: string = metadata.socials as string ?? "";
+      const company: string = metadata.company as string ?? "";
+
       return {
         userId: user.id,
+        firstName: user.firstName ?? "",
+        lastName: user.lastName ?? "",
         displayName: displayName,
-        description: "",
-        title: "",
-        socials: "",
-        company: "",
+        description,
+        title,
+        socials,
+        company,
         avatarUrl: user.imageUrl,
         initials: getInitialsFromString(displayName),
       }
@@ -37,13 +45,21 @@ export const userRouter = createTRPCRouter({
       const user = await clerkClient.users.getUser(userId);
       const displayName = `${user.firstName} ${user.lastName}`;
 
+      const metadata = user.publicMetadata;
+      const description: string = metadata.description as string ?? "";
+      const title: string = metadata.title as string ?? "";
+      const socials: string = metadata.socials as string ?? "";
+      const company: string = metadata.company as string ?? "";
+
       return {
         userId: user.id,
+        firstName: user.firstName ?? "",
+        lastName: user.lastName ?? "",
         displayName: displayName,
-        description: "",
-        title: "",
-        socials: "",
-        company: "",
+        description,
+        title,
+        socials,
+        company,
         avatarUrl: user.imageUrl,
         initials: getInitialsFromString(displayName),
       }
@@ -51,8 +67,25 @@ export const userRouter = createTRPCRouter({
 
   update: protectedProcedure
     .input(UpdateUserProfileDto)
-    .mutation(async ({input}): Promise<boolean> => {
-      // todo: push changes to flowcore
+    .mutation(async ({ctx, input}): Promise<boolean> => {
+
+      const userId = ctx.auth?.userId;
+
+      await clerkClient.users.updateUser(userId, {
+        firstName: input.firstName,
+        lastName: input.lastName,
+      });
+
+      await clerkClient.users.updateUserMetadata(userId, {
+        publicMetadata: {
+          title: input.title,
+          description: input.description,
+          socials: input.socials,
+          company: input.company,
+        }
+      });
+
+      // todo: update avatar
       console.log("user updated", input);
       return true;
     })

--- a/src/server/lib/format/get-initials-from-string.ts
+++ b/src/server/lib/format/get-initials-from-string.ts
@@ -1,0 +1,12 @@
+/**
+ * Extracts initials from a string.
+ *
+ * @param str - The input string.
+ * @returns The initials extracted from the string.
+ * @example Chandler Murial Bing -> CMB
+ */
+export const getInitialsFromString = (str: string) => {
+  const names = str.split(" ");
+  const initials = names.map((name) => name.charAt(0).toUpperCase());
+  return initials.join("");
+}


### PR DESCRIPTION
This task relies on a previous PR to be completed, as it builds on top of that implementation:


Using the private metadata fields in Clerk, we, can quite easily define roles, without having to rely on the setting up custom organizations for each event.
Whether that becomes relevant at a later stage, I am not sure. However the code is abstracted enough to be able to easily replace the current role fetching.

How you setup a roles-based solution with metadata is shown in their guide, here: 
https://clerk.com/docs/guides/basic-rbac