### PR TITLE
refactor: moved dto objects into contracts

### DIFF
--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,6 +1,6 @@
 import {api} from "@/trpc/server";
 import {UserProfileForm} from "@/components/organisms/profile/user-profile-form";
-import {UserProfile} from "@/components/organisms/profile/user-profile";
+import {UserProfileView} from "@/components/organisms/profile/user-profile-view";
 import {Card, CardContent, CardHeader} from "@/components/ui/card";
 import Link from "next/link";
 import {Button} from "@/components/ui/button";
@@ -26,7 +26,7 @@ export default async function MyUserRedirectPage() {
           </div>
         </CardHeader>
         <CardContent className={"px-3"}>
-          <UserProfile user={user}/>
+          <UserProfileView user={user}/>
         </CardContent>
       </Card>
 

--- a/src/app/users/[user]/page.tsx
+++ b/src/app/users/[user]/page.tsx
@@ -1,5 +1,5 @@
 import {api} from "@/trpc/server";
-import {UserProfile} from "@/components/organisms/profile/user-profile";
+import {UserProfileView} from "@/components/organisms/profile/user-profile-view";
 import {type WithUrlParams} from "@/lib/next-app.types";
 
 export type UserProfileProps = {
@@ -14,7 +14,7 @@ export default async function User({params}: WithUrlParams<UserProfileProps>) {
 
   return (
     <div>
-      <UserProfile
+      <UserProfileView
         user={user}
       />
     </div>

--- a/src/components/restricted-to-role.tsx
+++ b/src/components/restricted-to-role.tsx
@@ -1,9 +1,9 @@
-import {type UserRoleDto} from "@/dtos/user/user-role.dto";
+import {type UserRole} from "@/contracts/user/user-role";
 import {type FC, type PropsWithChildren} from "react";
 import {api} from "@/trpc/react";
 
 export type RestrictedToRoleProps = {
-  role: UserRoleDto;
+  role: UserRole;
 }
 
 /**

--- a/src/contracts/authorization/set-user-role-input.ts
+++ b/src/contracts/authorization/set-user-role-input.ts
@@ -1,6 +1,6 @@
 import {z} from "zod";
 
-export const SetUserRoleDto = z.object({
+export const SetUserRoleInput = z.object({
   userId: z.string().min(1),
   role: z.union([
     z.literal("admin"),

--- a/src/contracts/profile/update-profile-input.ts
+++ b/src/contracts/profile/update-profile-input.ts
@@ -1,6 +1,6 @@
 import {z} from "zod";
 
-export const UpdateUserProfileDto = z.object({
+export const UpdateUserProfileInput = z.object({
   firstName: z.string().min(1).max(255),
   lastName: z.string().min(1).max(255),
   title: z.string().optional(),

--- a/src/contracts/profile/user-profile.ts
+++ b/src/contracts/profile/user-profile.ts
@@ -1,4 +1,4 @@
-export type UserProfileDto = {
+export type UserProfile = {
   userId: string;
   displayName: string;
   firstName: string;

--- a/src/contracts/user/user-by-id-input.ts
+++ b/src/contracts/user/user-by-id-input.ts
@@ -1,5 +1,5 @@
 import {z} from "zod";
 
-export const UserByIdDto = z.object({
+export const UserByIdInput = z.object({
   userId: z.string().min(1)
 })

--- a/src/contracts/user/user-role.ts
+++ b/src/contracts/user/user-role.ts
@@ -1,0 +1,1 @@
+export type UserRole = "admin" | "user";

--- a/src/dtos/user/user-role.dto.ts
+++ b/src/dtos/user/user-role.dto.ts
@@ -1,1 +1,0 @@
-export type UserRoleDto = "admin" | "user";

--- a/src/server/api/routers/authorization.ts
+++ b/src/server/api/routers/authorization.ts
@@ -1,23 +1,23 @@
 import {createTRPCRouter, protectedProcedure} from "@/server/api/trpc";
-import {type UserRoleDto} from "@/dtos/user/user-role.dto";
+import {type UserRole} from "@/contracts/user/user-role";
 import {clerkClient} from "@clerk/nextjs/server";
-import {SetUserRoleDto} from "@/dtos/authorization/set-user-role.dto";
+import {SetUserRoleInput} from "@/contracts/authorization/set-user-role-input";
 import {verifyUserIdMiddleware} from "@/server/api/routers/middlewares/verify-user-id.middleware";
 import {adminsOnlyMiddleware} from "@/server/api/routers/middlewares/admins-only.middleware";
 
 export const authorizationRouter = createTRPCRouter({
   role: protectedProcedure
     .use(verifyUserIdMiddleware)
-    .query(async ({ctx}): Promise<UserRoleDto> => {
+    .query(async ({ctx}): Promise<UserRole> => {
 
       const user = await clerkClient.users.getUser(ctx.auth!.userId);
       const privateMetadata = user.privateMetadata;
 
-      return privateMetadata.role as UserRoleDto ?? "user";
+      return privateMetadata.role as UserRole ?? "user";
     }),
 
   setRole: protectedProcedure
-    .input(SetUserRoleDto)
+    .input(SetUserRoleInput)
     .use(adminsOnlyMiddleware)
     .mutation(async ({input}) => {
       await clerkClient.users.updateUserMetadata(input.userId, {

--- a/src/server/api/routers/user.ts
+++ b/src/server/api/routers/user.ts
@@ -1,14 +1,14 @@
 import {createTRPCRouter, protectedProcedure} from "@/server/api/trpc";
 import {clerkClient} from "@clerk/nextjs/server";
-import {UserByIdDto} from "@/dtos/user/user-by-id.dto";
-import {type UserProfileDto} from "@/dtos/profile/user-profile.dto";
-import {UpdateUserProfileDto} from "@/dtos/profile/update-profile.dto";
+import {UserByIdInput} from "@/contracts/user/user-by-id-input";
+import {type UserProfile} from "@/contracts/profile/user-profile";
+import {UpdateUserProfileInput} from "@/contracts/profile/update-profile-input";
 import {getInitialsFromString} from "@/server/lib/format/get-initials-from-string";
 
 export const userRouter = createTRPCRouter({
   get: protectedProcedure
-    .input(UserByIdDto)
-    .query(async ({input}): Promise<UserProfileDto> => {
+    .input(UserByIdInput)
+    .query(async ({input}): Promise<UserProfile> => {
 
       const user = await clerkClient.users.getUser(input.userId);
       const displayName = `${user.firstName} ${user.lastName}`;
@@ -34,7 +34,7 @@ export const userRouter = createTRPCRouter({
     }),
 
   me: protectedProcedure
-    .query(async ({ctx}): Promise<UserProfileDto> => {
+    .query(async ({ctx}): Promise<UserProfile> => {
 
       const userId = ctx.auth?.userId;
       if (!userId) {
@@ -66,7 +66,7 @@ export const userRouter = createTRPCRouter({
     }),
 
   update: protectedProcedure
-    .input(UpdateUserProfileDto)
+    .input(UpdateUserProfileInput)
     .mutation(async ({ctx, input}): Promise<boolean> => {
 
       const userId = ctx.auth?.userId;


### PR DESCRIPTION
- Moved everything in the dto to the contract folder 
- Renamed the `UserProfile` component to `UserProfileView` to avoid name conflicts
- Renamed all the dtos, by either removing the postfix, or replaced it with _input_